### PR TITLE
Add mongodb queries (Create, Find, Delete) to graphql resolvers

### DIFF
--- a/database/crudQuery.go
+++ b/database/crudQuery.go
@@ -5,14 +5,17 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"log"
+
+	"github.com/dnovaes/portfolio/gqlgen/graph/model"
 )
 
-func getCollection(collName string) *mongo.Collection {
+func GetCollection(collName string) *mongo.Collection {
 	var client = Db.client
 	return client.Database(database).Collection(collName)
 }
 
-func insert(coll *mongo.Collection, doc primitive.D) *mongo.InsertOneResult {
+func Insert(coll *mongo.Collection, doc primitive.D) *mongo.InsertOneResult {
 	result, err := coll.InsertOne(context.Background(), doc)
 	if err != nil {
 		panic(err)
@@ -20,7 +23,7 @@ func insert(coll *mongo.Collection, doc primitive.D) *mongo.InsertOneResult {
 	return result
 }
 
-func insertMany(coll *mongo.Collection, docs []interface{}) *mongo.InsertManyResult {
+func InsertMany(coll *mongo.Collection, docs []interface{}) *mongo.InsertManyResult {
 	result, err := coll.InsertMany(context.Background(), docs)
 	if err != nil {
 		panic(err)
@@ -28,7 +31,7 @@ func insertMany(coll *mongo.Collection, docs []interface{}) *mongo.InsertManyRes
 	return result
 }
 
-func delete(coll *mongo.Collection, doc primitive.D) *mongo.DeleteResult {
+func Delete(coll *mongo.Collection, doc primitive.D) *mongo.DeleteResult {
 	result, err := coll.DeleteOne(context.Background(), doc)
 	if err != nil {
 		panic(err)
@@ -36,7 +39,7 @@ func delete(coll *mongo.Collection, doc primitive.D) *mongo.DeleteResult {
 	return result
 }
 
-func deleteMany(coll *mongo.Collection, doc primitive.D) *mongo.DeleteResult {
+func DeleteMany(coll *mongo.Collection, doc primitive.D) *mongo.DeleteResult {
 	result, err := coll.DeleteMany(context.Background(), doc)
 	if err != nil {
 		panic(err)
@@ -44,8 +47,24 @@ func deleteMany(coll *mongo.Collection, doc primitive.D) *mongo.DeleteResult {
 	return result
 }
 
-func findAll(coll *mongo.Collection) []bson.M {
+func FindAll(coll *mongo.Collection) []bson.M {
 	var results []bson.M
+	cursorResult, err := coll.Find(context.Background(), bson.D{})
+
+	if err != nil {
+		panic(err)
+	}
+	err = cursorResult.All(context.TODO(), &results)
+	if err != nil {
+		panic(err)
+	}
+
+	return results
+}
+
+func FindAllContacts() []*model.Contact {
+	coll := GetCollection("contacts")
+	var results []*model.Contact
 	cursorResult, err := coll.Find(context.Background(), bson.D{})
 	if err != nil {
 		panic(err)
@@ -53,7 +72,20 @@ func findAll(coll *mongo.Collection) []bson.M {
 
 	err = cursorResult.All(context.TODO(), &results)
 	if err != nil {
+		log.Println(err)
 		panic(err)
 	}
 	return results
+}
+
+func FindAndDeleteContact(id primitive.ObjectID) *model.Contact {
+	coll := GetCollection("contacts")
+
+	var deletedContact *model.Contact
+	err := coll.FindOneAndDelete(context.Background(), bson.D{{"_id", id}}).Decode(&deletedContact)
+	if err == mongo.ErrNoDocuments {
+		log.Println("FindAndDeleteContact: ", err)
+		return nil
+	}
+	return deletedContact
 }

--- a/database/crudQuery.go
+++ b/database/crudQuery.go
@@ -20,6 +20,14 @@ func insert(coll *mongo.Collection, doc primitive.D) *mongo.InsertOneResult {
 	return result
 }
 
+func insertMany(coll *mongo.Collection, docs []interface{}) *mongo.InsertManyResult {
+	result, err := coll.InsertMany(context.Background(), docs)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
 func delete(coll *mongo.Collection, doc primitive.D) *mongo.DeleteResult {
 	result, err := coll.DeleteOne(context.Background(), doc)
 	if err != nil {

--- a/database/crudQuery.go
+++ b/database/crudQuery.go
@@ -1,0 +1,51 @@
+package database
+
+import (
+	"context"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func getCollection(collName string) *mongo.Collection {
+	var client = Db.client
+	return client.Database(database).Collection(collName)
+}
+
+func insert(coll *mongo.Collection, doc primitive.D) *mongo.InsertOneResult {
+	result, err := coll.InsertOne(context.Background(), doc)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+func delete(coll *mongo.Collection, doc primitive.D) *mongo.DeleteResult {
+	result, err := coll.DeleteOne(context.Background(), doc)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+func deleteMany(coll *mongo.Collection, doc primitive.D) *mongo.DeleteResult {
+	result, err := coll.DeleteMany(context.Background(), doc)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+func findAll(coll *mongo.Collection) []bson.M {
+	var results []bson.M
+	cursorResult, err := coll.Find(context.Background(), bson.D{})
+	if err != nil {
+		panic(err)
+	}
+
+	err = cursorResult.All(context.TODO(), &results)
+	if err != nil {
+		panic(err)
+	}
+	return results
+}

--- a/database/crudQuery_test.go
+++ b/database/crudQuery_test.go
@@ -33,6 +33,33 @@ func TestInsert(t *testing.T) {
 	StopConnection()
 }
 
+func TestInsertMany(t *testing.T) {
+	StartConnection()
+	coll := getCollection("contacts")
+
+	docs := []interface{}{
+		bson.D{
+			{Key: "name", Value: "contactName #1"},
+			{Key: "email", Value: "askdjasdl@mail.com"},
+			{Key: "message", Value: "its a message #1"},
+			{Key: "createdAt", Value: 123455677},
+		},
+		bson.D{
+			{Key: "name", Value: "contactName #2"},
+			{Key: "email", Value: "askdjasdl2@mail.com"},
+			{Key: "message", Value: "its a message #2"},
+			{Key: "createdAt", Value: 123455677},
+		},
+	}
+
+	result := insertMany(coll, docs)
+	assert.NotNil(t, result.InsertedIDs)
+	assert.Equal(t, 2, len(result.InsertedIDs))
+	coll.Drop(nil)
+
+	StopConnection()
+}
+
 func TestFindAll(t *testing.T) {
 	StartConnection()
 

--- a/database/crudQuery_test.go
+++ b/database/crudQuery_test.go
@@ -1,0 +1,86 @@
+package database
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"testing"
+)
+
+func TestGetCollection(t *testing.T) {
+	StartConnection()
+
+	collection := getCollection("contacts")
+	assert.NotNil(t, collection)
+
+	StopConnection()
+}
+
+func TestInsert(t *testing.T) {
+	StartConnection()
+	coll := getCollection("contacts")
+
+	bsonDoc := bson.D{
+		{Key: "name", Value: "contactName #1"},
+		{Key: "email", Value: "askdjasdl@mail.com"},
+		{Key: "message", Value: "its a message #1"},
+		{Key: "createdAt", Value: 123455677},
+	}
+
+	result := insert(coll, bsonDoc)
+	assert.NotNil(t, result.InsertedID)
+	deleteMany(coll, bsonDoc)
+
+	StopConnection()
+}
+
+func TestFindAll(t *testing.T) {
+	StartConnection()
+
+	coll := getCollection("test_contacts")
+	coll.Drop(nil)
+
+	bsonDoc1 := bson.D{
+		{Key: "name", Value: "contactName #1"},
+		{Key: "email", Value: "askdjasdl@mail.com"},
+		{Key: "message", Value: "its a message #1"},
+		{Key: "createdAt", Value: 123455677},
+	}
+	insert(coll, bsonDoc1)
+	bsonDoc2 := bson.D{
+		{Key: "name", Value: "contactName #2"},
+		{Key: "email", Value: "askdjasdl@mail.com"},
+		{Key: "message", Value: "its a message #2"},
+		{Key: "createdAt", Value: 123455677},
+	}
+	insert(coll, bsonDoc2)
+	result := findAll(coll)
+	assert.Equal(t, 2, len(result))
+
+	coll.Drop(nil)
+	result = findAll(coll)
+	assert.Equal(t, 0, len(result))
+
+	StopConnection()
+}
+
+func TestDeleteOne(t *testing.T) {
+	StartConnection()
+
+	coll := getCollection("test_contacts")
+	coll.Drop(nil)
+
+	bsonDoc1 := bson.D{
+		{Key: "name", Value: "contactName #1"},
+		{Key: "email", Value: "askdjasdl@mail.com"},
+		{Key: "message", Value: "its a message #1"},
+		{Key: "createdAt", Value: 123455677},
+	}
+	insert(coll, bsonDoc1)
+	resultDelete := delete(coll, bson.D{
+		{Key: "name", Value: "contactName #1"},
+	})
+	assert.Equal(t, int64(1), resultDelete.DeletedCount)
+	coll.Drop(nil)
+
+	StopConnection()
+}

--- a/database/database.go
+++ b/database/database.go
@@ -25,8 +25,9 @@ type DbCredentials struct {
 
 var Db DbConnection
 var credentials DbCredentials
-
 var hostURI string
+
+const database string = "dnovaes"
 
 func init() {
 	loadCredentials()

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,7 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.mongodb.org/mongo-driver v1.4.0 h1:C8rFn1VF4GVEM/rG+dSoMmlm2pyQ9cs2/oRtUATejRU=
 go.mongodb.org/mongo-driver v1.4.0/go.mod h1:llVBH2pkj9HywK0Dtdt6lDikOjFLbceHVu/Rc0iMKLs=
+go.mongodb.org/mongo-driver v1.4.1 h1:38NSAyDPagwnFpUA/D5SFgbugUYR3NzYRNa4Qk9UxKs=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,7 @@ github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -219,6 +220,7 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -226,6 +228,7 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20180121065927-ffb13db8def0/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -262,6 +265,7 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/urfave/cli/v2 v2.1.1 h1:Qt8FeAtxE/vfdrLmR3rxR6JRE0RoVmbXu8+6kZtYU4k=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
 github.com/vektah/gqlparser v1.3.1 h1:8b0IcD3qZKWJQHSzynbDlrtP3IxVydZ2DZepCGofqfU=
@@ -389,6 +393,7 @@ golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200114235610-7ae403b6b589 h1:rjUrONFu4kLchcZTfp3/96bR8bW8dIa8uz3cR5n0cgM=
 golang.org/x/tools v0.0.0-20200114235610-7ae403b6b589/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/gqlgen/gqlgen.yml
+++ b/gqlgen/gqlgen.yml
@@ -35,7 +35,7 @@ resolver:
 # gqlgen will search for any type names in the schema in these go packages
 # if they match it will use them, otherwise it will generate them.
 autobind:
-  - "github.com/dnovaes/gqlgen/graph/model"
+  - "github.com/dnovaes/portfolio/gqlgen/graph/model"
 
 # This section declares type mapping between the GraphQL and go type systems
 #
@@ -45,6 +45,7 @@ autobind:
 models:
   ID:
     model:
+      - github.com/dnovaes/portfolio/gqlgen/graph/model.ID
       - github.com/99designs/gqlgen/graphql.ID
       - github.com/99designs/gqlgen/graphql.Int
       - github.com/99designs/gqlgen/graphql.Int64
@@ -55,4 +56,4 @@ models:
       - github.com/99designs/gqlgen/graphql.Int64
       - github.com/99designs/gqlgen/graphql.Int32
   Timestamp:
-    model: github.com/dnovaes/gqlgen/graph/model.Timestamp
+    model: github.com/dnovaes/portfolio/gqlgen/graph/model.Timestamp

--- a/gqlgen/graph/generated/generated.go
+++ b/gqlgen/graph/generated/generated.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dnovaes/portfolio/gqlgen/graph/model"
 	gqlparser "github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // region    ************************** generated!.gotpl **************************
@@ -66,6 +67,7 @@ type ComplexityRoot struct {
 	Mutation struct {
 		CreateContact    func(childComplexity int, input model.NewContact) int
 		CreateExperience func(childComplexity int, input model.NewExperience) int
+		DeleteContact    func(childComplexity int, id primitive.ObjectID) int
 	}
 
 	Query struct {
@@ -77,6 +79,7 @@ type ComplexityRoot struct {
 type MutationResolver interface {
 	CreateContact(ctx context.Context, input model.NewContact) (*model.Contact, error)
 	CreateExperience(ctx context.Context, input model.NewExperience) (*model.Experience, error)
+	DeleteContact(ctx context.Context, id primitive.ObjectID) (*model.Contact, error)
 }
 type QueryResolver interface {
 	Contacts(ctx context.Context) ([]*model.Contact, error)
@@ -112,7 +115,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Contact.Email(childComplexity), true
 
-	case "Contact.id":
+	case "Contact._id":
 		if e.complexity.Contact.ID == nil {
 			break
 		}
@@ -212,6 +215,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.CreateExperience(childComplexity, args["input"].(model.NewExperience)), true
+
+	case "Mutation.deleteContact":
+		if e.complexity.Mutation.DeleteContact == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteContact_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteContact(childComplexity, args["id"].(primitive.ObjectID)), true
 
 	case "Query.contacts":
 		if e.complexity.Query.Contacts == nil {
@@ -315,8 +330,12 @@ input NewExperience {
   finishedAt: Timestamp
 }
 
+directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITION
+    | FIELD_DEFINITION
+
+
 type Contact {
-  id: ID!
+  _id: ID! @goField(name: "id")
   name: String!
   email: String!
   message: String!
@@ -337,6 +356,7 @@ type Query {
 type Mutation {
   createContact(input: NewContact!): Contact!
   createExperience(input: NewExperience!): Experience!
+  deleteContact(id: ID!): Contact!
 }
 
 scalar Timestamp
@@ -354,7 +374,7 @@ func (ec *executionContext) field_Mutation_createContact_args(ctx context.Contex
 	var arg0 model.NewContact
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("input"))
-		arg0, err = ec.unmarshalNNewContact2githubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐNewContact(ctx, tmp)
+		arg0, err = ec.unmarshalNNewContact2githubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐNewContact(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -369,12 +389,27 @@ func (ec *executionContext) field_Mutation_createExperience_args(ctx context.Con
 	var arg0 model.NewExperience
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("input"))
-		arg0, err = ec.unmarshalNNewExperience2githubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐNewExperience(ctx, tmp)
+		arg0, err = ec.unmarshalNNewExperience2githubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐNewExperience(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
 	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteContact_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 primitive.ObjectID
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithFieldInputContext(ctx, graphql.NewFieldInputWithField("id"))
+		arg0, err = ec.unmarshalNID2goᚗmongodbᚗorgᚋmongoᚑdriverᚋbsonᚋprimitiveᚐObjectID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
 	return args, nil
 }
 
@@ -431,7 +466,7 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 
 // region    **************************** field.gotpl *****************************
 
-func (ec *executionContext) _Contact_id(ctx context.Context, field graphql.CollectedField, obj *model.Contact) (ret graphql.Marshaler) {
+func (ec *executionContext) _Contact__id(ctx context.Context, field graphql.CollectedField, obj *model.Contact) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -460,9 +495,9 @@ func (ec *executionContext) _Contact_id(ctx context.Context, field graphql.Colle
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(primitive.ObjectID)
 	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
+	return ec.marshalNID2goᚗmongodbᚗorgᚋmongoᚑdriverᚋbsonᚋprimitiveᚐObjectID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Contact_name(ctx context.Context, field graphql.CollectedField, obj *model.Contact) (ret graphql.Marshaler) {
@@ -627,9 +662,9 @@ func (ec *executionContext) _Experience_id(ctx context.Context, field graphql.Co
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(primitive.ObjectID)
 	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
+	return ec.marshalNID2goᚗmongodbᚗorgᚋmongoᚑdriverᚋbsonᚋprimitiveᚐObjectID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Experience_title(ctx context.Context, field graphql.CollectedField, obj *model.Experience) (ret graphql.Marshaler) {
@@ -899,7 +934,7 @@ func (ec *executionContext) _Mutation_createContact(ctx context.Context, field g
 	}
 	res := resTmp.(*model.Contact)
 	fc.Result = res
-	return ec.marshalNContact2ᚖgithubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐContact(ctx, field.Selections, res)
+	return ec.marshalNContact2ᚖgithubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐContact(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_createExperience(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -940,7 +975,48 @@ func (ec *executionContext) _Mutation_createExperience(ctx context.Context, fiel
 	}
 	res := resTmp.(*model.Experience)
 	fc.Result = res
-	return ec.marshalNExperience2ᚖgithubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐExperience(ctx, field.Selections, res)
+	return ec.marshalNExperience2ᚖgithubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐExperience(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_deleteContact(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_deleteContact_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteContact(rctx, args["id"].(primitive.ObjectID))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Contact)
+	fc.Result = res
+	return ec.marshalNContact2ᚖgithubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐContact(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_contacts(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -974,7 +1050,7 @@ func (ec *executionContext) _Query_contacts(ctx context.Context, field graphql.C
 	}
 	res := resTmp.([]*model.Contact)
 	fc.Result = res
-	return ec.marshalNContact2ᚕᚖgithubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐContactᚄ(ctx, field.Selections, res)
+	return ec.marshalNContact2ᚕᚖgithubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐContactᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_experiences(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -1008,7 +1084,7 @@ func (ec *executionContext) _Query_experiences(ctx context.Context, field graphq
 	}
 	res := resTmp.([]*model.Experience)
 	fc.Result = res
-	return ec.marshalNExperience2ᚕᚖgithubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐExperienceᚄ(ctx, field.Selections, res)
+	return ec.marshalNExperience2ᚕᚖgithubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐExperienceᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -2258,8 +2334,8 @@ func (ec *executionContext) _Contact(ctx context.Context, sel ast.SelectionSet, 
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Contact")
-		case "id":
-			out.Values[i] = ec._Contact_id(ctx, field, obj)
+		case "_id":
+			out.Values[i] = ec._Contact__id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -2366,6 +2442,11 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			}
 		case "createExperience":
 			out.Values[i] = ec._Mutation_createExperience(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "deleteContact":
+			out.Values[i] = ec._Mutation_deleteContact(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -2698,11 +2779,11 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
-func (ec *executionContext) marshalNContact2githubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐContact(ctx context.Context, sel ast.SelectionSet, v model.Contact) graphql.Marshaler {
+func (ec *executionContext) marshalNContact2githubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐContact(ctx context.Context, sel ast.SelectionSet, v model.Contact) graphql.Marshaler {
 	return ec._Contact(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNContact2ᚕᚖgithubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐContactᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Contact) graphql.Marshaler {
+func (ec *executionContext) marshalNContact2ᚕᚖgithubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐContactᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Contact) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -2726,7 +2807,7 @@ func (ec *executionContext) marshalNContact2ᚕᚖgithubᚗcomᚋdnovaesᚋgqlge
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNContact2ᚖgithubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐContact(ctx, sel, v[i])
+			ret[i] = ec.marshalNContact2ᚖgithubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐContact(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -2739,7 +2820,7 @@ func (ec *executionContext) marshalNContact2ᚕᚖgithubᚗcomᚋdnovaesᚋgqlge
 	return ret
 }
 
-func (ec *executionContext) marshalNContact2ᚖgithubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐContact(ctx context.Context, sel ast.SelectionSet, v *model.Contact) graphql.Marshaler {
+func (ec *executionContext) marshalNContact2ᚖgithubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐContact(ctx context.Context, sel ast.SelectionSet, v *model.Contact) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "must not be null")
@@ -2749,11 +2830,11 @@ func (ec *executionContext) marshalNContact2ᚖgithubᚗcomᚋdnovaesᚋgqlgen�
 	return ec._Contact(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNExperience2githubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐExperience(ctx context.Context, sel ast.SelectionSet, v model.Experience) graphql.Marshaler {
+func (ec *executionContext) marshalNExperience2githubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐExperience(ctx context.Context, sel ast.SelectionSet, v model.Experience) graphql.Marshaler {
 	return ec._Experience(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNExperience2ᚕᚖgithubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐExperienceᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Experience) graphql.Marshaler {
+func (ec *executionContext) marshalNExperience2ᚕᚖgithubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐExperienceᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Experience) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -2777,7 +2858,7 @@ func (ec *executionContext) marshalNExperience2ᚕᚖgithubᚗcomᚋdnovaesᚋgq
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNExperience2ᚖgithubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐExperience(ctx, sel, v[i])
+			ret[i] = ec.marshalNExperience2ᚖgithubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐExperience(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -2790,7 +2871,7 @@ func (ec *executionContext) marshalNExperience2ᚕᚖgithubᚗcomᚋdnovaesᚋgq
 	return ret
 }
 
-func (ec *executionContext) marshalNExperience2ᚖgithubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐExperience(ctx context.Context, sel ast.SelectionSet, v *model.Experience) graphql.Marshaler {
+func (ec *executionContext) marshalNExperience2ᚖgithubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐExperience(ctx context.Context, sel ast.SelectionSet, v *model.Experience) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "must not be null")
@@ -2800,13 +2881,13 @@ func (ec *executionContext) marshalNExperience2ᚖgithubᚗcomᚋdnovaesᚋgqlge
 	return ec._Experience(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface{}) (string, error) {
-	res, err := graphql.UnmarshalID(v)
+func (ec *executionContext) unmarshalNID2goᚗmongodbᚗorgᚋmongoᚑdriverᚋbsonᚋprimitiveᚐObjectID(ctx context.Context, v interface{}) (primitive.ObjectID, error) {
+	res, err := model.UnmarshalID(v)
 	return res, graphql.WrapErrorWithInputPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
-	res := graphql.MarshalID(v)
+func (ec *executionContext) marshalNID2goᚗmongodbᚗorgᚋmongoᚑdriverᚋbsonᚋprimitiveᚐObjectID(ctx context.Context, sel ast.SelectionSet, v primitive.ObjectID) graphql.Marshaler {
+	res := model.MarshalID(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "must not be null")
@@ -2830,12 +2911,12 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 	return res
 }
 
-func (ec *executionContext) unmarshalNNewContact2githubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐNewContact(ctx context.Context, v interface{}) (model.NewContact, error) {
+func (ec *executionContext) unmarshalNNewContact2githubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐNewContact(ctx context.Context, v interface{}) (model.NewContact, error) {
 	res, err := ec.unmarshalInputNewContact(ctx, v)
 	return res, graphql.WrapErrorWithInputPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNNewExperience2githubᚗcomᚋdnovaesᚋgqlgenᚋgraphᚋmodelᚐNewExperience(ctx context.Context, v interface{}) (model.NewExperience, error) {
+func (ec *executionContext) unmarshalNNewExperience2githubᚗcomᚋdnovaesᚋportfolioᚋgqlgenᚋgraphᚋmodelᚐNewExperience(ctx context.Context, v interface{}) (model.NewExperience, error) {
 	res, err := ec.unmarshalInputNewExperience(ctx, v)
 	return res, graphql.WrapErrorWithInputPath(ctx, err)
 }

--- a/gqlgen/graph/model/model.go
+++ b/gqlgen/graph/model/model.go
@@ -3,11 +3,12 @@ package model
 import (
 	"errors"
 	"io"
+	"log"
 	"strconv"
-	_ "strings"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // if the type referenced in .gqlgen.yml is a function that returns a marshaller we can use it to encode and decode
@@ -24,5 +25,20 @@ func UnmarshalTimestamp(v interface{}) (time.Time, error) {
 	if tmpStr, ok := v.(int64); ok {
 		return time.Unix(tmpStr, 0), nil
 	}
-	return time.Time{}, errors.New("time should be a unix timestamp")
+	return time.Time{}, errors.New("Error unmarshal timestamp: time should be a unix timestamp")
+}
+
+func MarshalID(id primitive.ObjectID) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		io.WriteString(w, strconv.Quote(id.Hex()))
+	})
+}
+
+func UnmarshalID(v interface{}) (primitive.ObjectID, error) {
+	objectId, err := primitive.ObjectIDFromHex(v.(string))
+	if err != nil {
+		log.Println(err)
+		return objectId, errors.New("Error unmarshal ID: Couldn't extract objectId from Hex")
+	}
+	return objectId, nil
 }

--- a/gqlgen/graph/model/models_gen.go
+++ b/gqlgen/graph/model/models_gen.go
@@ -4,25 +4,27 @@ package model
 
 import (
 	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type Contact struct {
-	ID        string     `json:"id"`
-	Name      string     `json:"name"`
-	Email     string     `json:"email"`
-	Message   string     `json:"message"`
-	CreatedAt *time.Time `json:"createdAt"`
+	ID        primitive.ObjectID `json:"_id" bson:"_id,omitempty"`
+	Name      string             `json:"name"`
+	Email     string             `json:"email"`
+	Message   string             `json:"message"`
+	CreatedAt *time.Time         `json:"createdAt"`
 }
 
 type Experience struct {
-	ID          string     `json:"id"`
-	Title       string     `json:"title"`
-	Description string     `json:"description"`
-	Year        int        `json:"year"`
-	Company     string     `json:"company"`
-	CompanyLink *string    `json:"companyLink"`
-	StartedAt   *time.Time `json:"startedAt"`
-	FinishedAt  *time.Time `json:"finishedAt"`
+	ID          primitive.ObjectID `json:"id"`
+	Title       string             `json:"title"`
+	Description string             `json:"description"`
+	Year        int                `json:"year"`
+	Company     string             `json:"company"`
+	CompanyLink *string            `json:"companyLink"`
+	StartedAt   *time.Time         `json:"startedAt"`
+	FinishedAt  *time.Time         `json:"finishedAt"`
 }
 
 type NewContact struct {

--- a/gqlgen/graph/schema.graphqls
+++ b/gqlgen/graph/schema.graphqls
@@ -22,8 +22,12 @@ input NewExperience {
   finishedAt: Timestamp
 }
 
+directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITION
+    | FIELD_DEFINITION
+
+
 type Contact {
-  id: ID!
+  _id: ID! @goField(name: "id")
   name: String!
   email: String!
   message: String!
@@ -44,6 +48,7 @@ type Query {
 type Mutation {
   createContact(input: NewContact!): Contact!
   createExperience(input: NewExperience!): Experience!
+  deleteContact(id: ID!): Contact!
 }
 
 scalar Timestamp

--- a/gqlgen/graph/schema.resolvers.go
+++ b/gqlgen/graph/schema.resolvers.go
@@ -51,8 +51,9 @@ func (r *mutationResolver) CreateExperience(ctx context.Context, input model.New
 			return nil, errors.New(errorMessage)
 		}
 	}
+	newObjectId := primitive.NewObjectID()
 	newExperience := &model.Experience{
-		ID:          fmt.Sprintf("T%d", rand.Int()),
+		ID:          newObjectId,
 		Title:       input.Title,
 		Description: input.Description,
 		Year:        input.Year,


### PR DESCRIPTION
## Description

### Create mongodb queries and associate with **gqlgen** package:
- [x] Create find, insert, delete queries
- [x] Add specs -> _crudQuery_test.go_
- [x] Link created methods inside of gqlgen resolver
- [x] Fix bugs with (un)marshalling _id from mongodb.
- [x] Create new marshal/unmarshal for **_id** field
- [x] Add goDirective for _id field in Contact struct

TODO in future PR: queries should be more general (add use of interface{} in arguments)

### Demo Gif
Create - Read all - Delete
![crd_working](https://user-images.githubusercontent.com/3251916/92190351-51ba5780-ee37-11ea-98aa-3d5b4b92493e.gif)
